### PR TITLE
feat: Add type filter to /{user} and sync URL + RSS link

### DIFF
--- a/src/app/[user]/page.tsx
+++ b/src/app/[user]/page.tsx
@@ -4,6 +4,7 @@ import GhTimeline from "@/components/GhTimeline";
 import { fetchEventsWithEnv } from "./shared";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { Rss } from "lucide-react";
+import RssLink from "@/components/RssLink";
 import type { Metadata } from "next";
 
 export const runtime = "nodejs";
@@ -32,15 +33,7 @@ export default async function UserPage({ params, searchParams }: { params: Promi
           >
             View @{user} on GitHub
           </a>
-          <a
-            href={`/${user}/rss${typeParam ? `?type=${encodeURIComponent(typeParam)}` : ''}`}
-            className="inline-flex items-center gap-1.5 text-sm text-neutral-700 hover:text-neutral-900 dark:text-gray-300 dark:hover:text-gray-100"
-            aria-label={`RSS feed for @${user}`}
-            title="Subscribe to RSS feed"
-          >
-            <Rss className="w-4 h-4" />
-            <span>RSS Feed</span>
-          </a>
+          <RssLink user={user} />
         </div>
         <GhTimeline user={user} initial={filteredInitial} initialTypes={initialTypes} pollSec={meta.pollInterval ?? 60} />
       </div>

--- a/src/components/RssLink.tsx
+++ b/src/components/RssLink.tsx
@@ -1,0 +1,23 @@
+// src/components/RssLink.tsx
+"use client";
+
+import { Rss } from "lucide-react";
+import { useSearchParams } from "next/navigation";
+
+export default function RssLink({ user }: { user: string }) {
+  const sp = useSearchParams();
+  const type = sp?.get('type');
+  const href = `/${user}/rss${type ? `?type=${encodeURIComponent(type)}` : ''}`;
+  return (
+    <a
+      href={href}
+      className="inline-flex items-center gap-1.5 text-sm text-neutral-700 hover:text-neutral-900 dark:text-gray-300 dark:hover:text-gray-100"
+      aria-label={`RSS feed for @${user}`}
+      title="Subscribe to RSS feed"
+    >
+      <Rss className="w-4 h-4" />
+      <span>RSS Feed</span>
+    </a>
+  );
+}
+


### PR DESCRIPTION
# Summary
Enable event-type filtering on `/{user}` using `?type=` query and make the UI filter pills reflect in the URL. Keep the RSS link in sync with the current filter.

# Changes
- Add `searchParams` handling to `src/app/[user]/page.tsx` and pre-filter initial events by `type`
- Pass `initialTypes` to `GhTimeline` and initialize client-side filters from URL
- Sync filter selections to the URL query via `next/navigation` (`router.replace`)
- Add `src/components/RssLink.tsx` to keep the RSS link updated with the current `type` query
- Update the page header to use `RssLink` (dynamic, client-side)

# Why
- Shareable deep links to filtered timelines (e.g., push-only view)
- Parity with existing `/{user}/rss?type=...` support
- Better UX: filter choices are reflected in the URL and survive refresh/navigation

# Notes
- Multiple types are comma-separated: `?type=PushEvent,PullRequestEvent`
- Supported event types include: PushEvent, PullRequestEvent, IssuesEvent, IssueCommentEvent, PullRequestReviewEvent, PullRequestReviewCommentEvent, PullRequestReviewThreadEvent, ReleaseEvent, ForkEvent, WatchEvent, CreateEvent, DeleteEvent, PublicEvent, MemberEvent, CommitCommentEvent, GollumEvent
- Counters (commits/PRs/etc.) still compute from all events by design; the visible list is filtered
- Infinite scroll and background refresh fetch unfiltered events, but the visible list remains filtered in the client layer

# Testing
- Start dev server and open `http://localhost:3000/<user>`
  - Confirm default shows all events
- Visit with a filter: `http://localhost:3000/<user>?type=PushEvent`
  - Confirm only push events are rendered initially
  - Confirm the filter pill for PushEvent is selected
  - Confirm the header RSS link points to `/<user>/rss?type=PushEvent`
- Click additional filter pills (e.g., `PullRequestEvent`)
  - Confirm the URL updates to `?type=PushEvent,PullRequestEvent` without a full reload
  - Confirm the list shows only the selected types
  - Confirm the RSS link updates accordingly
- Scroll to trigger infinite load; new pages append but the visible list stays filtered
- Manually verify RSS: `curl -s 'http://localhost:3000/<user>/rss?type=PushEvent' | head`
  - Confirms server-side RSS filtering still works
