### PR TITLE
Add GitHub profile button to header actions

### DIFF
--- a/src/app/[user]/page.tsx
+++ b/src/app/[user]/page.tsx
@@ -21,7 +21,6 @@ export default async function UserPage({ params, searchParams }: { params: Promi
   return (
     <main className="min-h-dvh bg-gradient-to-b from-neutral-50 to-white dark:from-gray-900 dark:to-gray-950 text-neutral-900 dark:text-gray-100">
       <div className="mx-auto max-w-5xl p-6">
-        {/** moved GitHub profile link into GhTimeline header as a button */}
         <GhTimeline user={user} initial={filteredInitial} initialTypes={initialTypes} pollSec={meta.pollInterval ?? 60} />
       </div>
     </main>

--- a/src/app/[user]/page.tsx
+++ b/src/app/[user]/page.tsx
@@ -21,18 +21,7 @@ export default async function UserPage({ params, searchParams }: { params: Promi
   return (
     <main className="min-h-dvh bg-gradient-to-b from-neutral-50 to-white dark:from-gray-900 dark:to-gray-950 text-neutral-900 dark:text-gray-100">
       <div className="mx-auto max-w-5xl p-6">
-        <div className="mb-4 flex items-center gap-4">
-          <a
-            href={`https://github.com/${user}`}
-            target="_blank"
-            rel="noreferrer"
-            className="inline-flex items-center gap-2 text-sm text-neutral-700 hover:text-neutral-900 dark:text-gray-300 dark:hover:text-gray-100 underline underline-offset-2"
-            aria-label={`Open @${user} on GitHub`}
-          >
-            View @{user} on GitHub
-          </a>
-          
-        </div>
+        {/** moved GitHub profile link into GhTimeline header as a button */}
         <GhTimeline user={user} initial={filteredInitial} initialTypes={initialTypes} pollSec={meta.pollInterval ?? 60} />
       </div>
     </main>

--- a/src/components/GhTimeline.tsx
+++ b/src/components/GhTimeline.tsx
@@ -7,7 +7,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import {
   GitCommit, GitPullRequest, Star, GitFork, Tag,
   MessageSquare, GitBranch, GitMerge, Trash2, Users, Eye, Clock,
-  RefreshCw, ChevronDown, ChevronRight, Link2, AlertTriangle, Download,
+  RefreshCw, ChevronDown, ChevronRight, Link2, AlertTriangle, Download, Github,
   Unlock, BookOpen, MessageCircle
 } from "lucide-react";
 import { getEventsAction } from "@/app/[user]/actions";
@@ -516,6 +516,15 @@ export default function GhTimeline({
           >
             <Download className="w-4 h-4" />Export JSON
           </button>
+          <a
+            href={`https://github.com/${user}`}
+            target="_blank"
+            rel="noreferrer"
+            aria-label={`Open @${user} on GitHub`}
+            className="px-3 py-2 rounded-lg bg-white dark:bg-gray-800/50 text-neutral-700 dark:text-gray-100 border border-neutral-200 dark:border-gray-700/50 hover:bg-gray-50 hover:border-neutral-300 hover:shadow-sm dark:hover:bg-gray-800 inline-flex items-center gap-2 transition-all duration-200"
+          >
+            <Github className="w-4 h-4" />View @{user} on GitHub
+          </a>
         </div>
       </header>
 


### PR DESCRIPTION
## Summary
Make the GitHub profile link look and behave like the existing header action buttons.

## Changes
- Replace plain text profile link with a styled button (header actions)
- Add `Github` icon from `lucide-react`
- Remove the old link block from `src/app/[user]/page.tsx`
- Keep button styles consistent with RSS/Refresh/Export

## Why
- Aligns the “View @{username} on GitHub” control with the established header action pattern for better visual consistency and discoverability.
- Reduces duplicated header chrome by moving the link into the same action group.

## Notes
- Uses the same Tailwind utility classes as existing buttons for hover, border, dark mode, and spacing.
- The button opens `https://github.com/{user}` in a new tab with `rel="noreferrer"`.

## Testing
- Open a user page (e.g. `/octocat`).
- Verify the header now shows four actions: “RSS Feed”, “Refresh”, “Export JSON”, and “View @octocat on GitHub”.
- Confirm the new button includes the GitHub icon and matches spacing, border, hover, and dark-mode styles of the other buttons.
- Click the button and confirm it opens the correct GitHub profile in a new tab.
- Keyboard: Tab to the button and press Enter to open the link.
- Regression: Ensure RSS/Refresh/Export continue to work as before.
