### PR TITLE
Show PR body for PullRequestEvent in timeline and RSS

### DIFF
--- a/src/components/GhTimeline.tsx
+++ b/src/components/GhTimeline.tsx
@@ -661,9 +661,11 @@ function TimelineItem({ ev }: { ev: GithubEvent }) {
   const isIssueCmt = isIssueCommentEvent(ev);
   const isCommitCmt = isCommitCommentEvent(ev);
   const isPrReviewCmt = isPullRequestReviewCommentEvent(ev);
+  const isPrEvent = isPullRequestEvent(ev);
   const issueCommentBody = isIssueCmt ? (ev.payload.comment?.body || "") : "";
   const commitCommentBody = isCommitCmt ? (ev.payload.comment?.body || "") : "";
   const prReviewCommentBody = isPrReviewCmt ? (ev.payload.comment?.body || "") : "";
+  const prBody = isPrEvent ? (ev.payload.pull_request?.body || "") : "";
 
   return (
     <li className="mb-6">
@@ -728,6 +730,31 @@ function TimelineItem({ ev }: { ev: GithubEvent }) {
             ) : (
               <div className="mt-1 rounded-lg p-2 bg-white dark:bg-gray-900 border border-neutral-200 dark:border-gray-800 text-xs whitespace-pre-wrap break-words">
                 {issueCommentBody}
+              </div>
+            )}
+          </div>
+        )}
+
+        {isPrEvent && prBody && (
+          <div className="pl-6">
+            {prBody.length > 320 ? (
+              <div className="mt-1">
+                <button onClick={() => setOpen(v => !v)} className="inline-flex items-center gap-1 text-xs text-neutral-700 hover:text-neutral-900 dark:text-gray-300 dark:hover:text-gray-100">
+                  {open ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />} {open ? "Hide" : "Show"} description
+                </button>
+                <AnimatePresence>
+                  {open && (
+                    <motion.div initial={{ opacity: 0, height: 0 }} animate={{ opacity: 1, height: "auto" }} exit={{ opacity: 0, height: 0 }}>
+                      <div className="mt-2 rounded-lg p-2 bg-white dark:bg-gray-900 border border-neutral-200 dark:border-gray-800 text-xs whitespace-pre-wrap break-words">
+                        {prBody}
+                      </div>
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+              </div>
+            ) : (
+              <div className="mt-1 rounded-lg p-2 bg-white dark:bg-gray-900 border border-neutral-200 dark:border-gray-800 text-xs whitespace-pre-wrap break-words">
+                {prBody}
               </div>
             )}
           </div>

--- a/src/lib/rss-generator-feed.ts
+++ b/src/lib/rss-generator-feed.ts
@@ -2,6 +2,13 @@
 import { Feed } from "feed";
 import type { GithubEvent } from "./github-events-schema";
 
+function escapeHtml(s: string): string {
+  return s
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
 /**
  * Format GitHub event type to human-readable string
  */
@@ -49,8 +56,13 @@ function generateEventDescription(event: GithubEvent): string {
       
     case "PullRequestEvent":
       if (event.payload?.action && event.payload?.pull_request) {
-        const pr = event.payload.pull_request as { number?: number; title?: string };
+        const pr = event.payload.pull_request as { number?: number; title?: string; body?: string | null };
         description = `${actor} ${event.payload.action} pull request #${pr.number}: "${pr.title || ""}" in ${repo}`;
+        if (pr.body) {
+          const text = escapeHtml(pr.body);
+          const short = text.length > 500 ? `${text.slice(0, 500)}…` : text;
+          description += `<br/><br/>Description:<br/>${short.replaceAll("\n", "<br/>")}`;
+        }
       }
       break;
       


### PR DESCRIPTION
Summary

Display pull request body for PullRequestEvent in both the timeline UI and the RSS feed.

Changes

- Render `pull_request.body` for PullRequestEvent in timeline with a collapsible section (threshold: 320 chars)
- Include PR body in RSS description (HTML-escaped, newlines ->   
, truncated to 500 chars)
- Add lightweight HTML escaping util in RSS generator to prevent markup injection

Why
Showing the PR description provides more context alongside the existing title/action, aligning with how IssueComment bodies are already surfaced.

Notes

- Timeline only renders when a non-empty body exists; nothing changes for PRs without a body
- RSS description safely escapes `<`, `>`, and `&`; long texts are truncated to keep feeds readable
- No schema changes required; `pull_request.body` already exists in the payload schema
- Potential follow-up: when action == "edited", optionally show the previous body from `payload.changes.body.from`

Testing

- Local
    - Run `pnpm dev` and open `http://localhost:3000/<your-username>`
    - Confirm PullRequestEvent items with a non-empty body show a collapsible "Show/Hide description" panel
    - Verify long bodies (>320 chars) collapse by default and expand correctly
    - Confirm other event types remain unaffected
- RSS
    - Open `http://localhost:3000/<your-username>/rss`
    - Check the item for a PullRequestEvent includes the PR body snippet, escaped and truncated (up to 500 chars)
    - Validate that line breaks in the body render as `<br/>`
- Safety
    - Ensure no raw HTML from PR body is injected in the feed