### PR TITLE
chore(renovate): use config:best-practices preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:best-practices"
   ]
 }


### PR DESCRIPTION
# Summary

Switch Renovate preset from `config:recommended` to `config:best-practices`.

# Changes

- Update `renovate.json`: set `extends` to `"config:best-practices"`.

# Why

- Adopt Renovate's "best-practices" preset to apply safer defaults and reduce update noise compared to the base recommended preset.
- Keep configuration minimal while aligning with common maintenance practices.

# Notes

- No other Renovate options changed in this PR.
- Monitor subsequent Renovate runs and adjust if needed.

# Testing

- Validate JSON structure locally: `jq . renovate.json`.
- Optionally validate using Renovate's config validator: `npx -y renovate-config-validator`.
- After merge to the default branch, confirm the next Renovate run completes and future PRs reflect the preset.
- Ensure CI remains green for this change.