### PR TITLE
Ensure OpenNext build runs for preview and local Wrangler

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,13 +2,15 @@
 	"name": "ghactivity",
 	"version": "0.1.0",
 	"private": true,
-	"scripts": {
+  "scripts": {
 		"dev": "next dev --turbopack",
 		"build": "next build",
 		"start": "next start",
 		"lint": "next lint",
 		"predeploy": "rm -rf .next .open-next",
 		"deploy": "opennextjs-cloudflare build && opennextjs-cloudflare deploy",
+		"preupload": "rm -rf .next .open-next",
+		"upload": "opennextjs-cloudflare build && opennextjs-cloudflare upload",
 		"prepreview": "rm -rf .next .open-next",
 		"preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
 		"cf-typegen": "wrangler types --env-interface CloudflareEnv ./cloudflare-env.d.ts",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -7,6 +7,9 @@
 	"name": "ghactivity",
 	"account_id": "7329283460e5efe7b1e75190a87dfdd4",
 	"main": ".open-next/worker.js",
+	"build": {
+		"command": "pnpm opennextjs-cloudflare build"
+	},
 	"compatibility_date": "2025-03-01",
 	"compatibility_flags": [
 		"nodejs_compat",


### PR DESCRIPTION
Summary

Fix preview builds failing with "The entry-point file at .open-next/worker.js was not found" by ensuring the OpenNext Cloudflare build runs before any upload/versions deploy. Also wire Wrangler to invoke the build when developing locally.

Changes

- Add `preupload` and `upload` scripts in `package.json` (always run `opennextjs-cloudflare build` before `upload`).
- Add `build.command` to `wrangler.jsonc` to run `pnpm opennextjs-cloudflare build` prior to `wrangler dev/deploy`.

Why
Preview branches were using `wrangler versions upload` without building the OpenNext Cloudflare artifacts. On `main`, `pnpm run deploy` already performs the build, so the error did not repro there. Without the build, `.open-next/worker.js` does not exist and Wrangler fails.

Notes

- For Cloudflare Workers Git integration, align Non‑production (preview) commands with production:
    - Build command: `pnpm opennextjs-cloudflare build`
    - Deploy command: `pnpm run upload` (or `pnpm opennextjs-cloudflare build && npx wrangler versions upload`)
- `.open-next` remains untracked; every deploy must build first.

Testing

- Local: `pnpm install --frozen-lockfile && pnpm run upload` → confirm `.open-next/worker.js` exists, then `pnpm wrangler dev` runs.
- Preview (Git): set the preview Build/Deploy commands as above and push this branch → the version uploads without the entry‑point error.