### PR TITLE
Stop server-side type filtering on initial user page

### DIFF
--- a/src/app/[user]/page.tsx
+++ b/src/app/[user]/page.tsx
@@ -14,14 +14,11 @@ export default async function UserPage({ params, searchParams }: { params: Promi
   const initialTypes = typeParam ? typeParam.split(',').map(s => s.trim()).filter(Boolean) : [];
 
   const { events, meta } = await getEventsAction(user);
-  const filteredInitial = initialTypes.length > 0
-    ? events.filter(e => e.type && initialTypes.includes(e.type))
-    : events;
 
   return (
     <main className="min-h-dvh bg-gradient-to-b from-neutral-50 to-white dark:from-gray-900 dark:to-gray-950 text-neutral-900 dark:text-gray-100">
       <div className="mx-auto max-w-5xl p-6">
-        <GhTimeline user={user} initial={filteredInitial} initialTypes={initialTypes} pollSec={meta.pollInterval ?? 60} />
+        <GhTimeline user={user} initial={events} initialTypes={initialTypes} pollSec={meta.pollInterval ?? 60} />
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary
Stop server-side type-based filtering on the initial user page request. Always pass the full first page of events to the client, while keeping client-side display filtering via the `type` query parameter.

## Changes
- Remove server-side filtering by `type` in `src/app/[user]/page.tsx`
- Pass `events` directly to `GhTimeline` as `initial`
- Keep `initialTypes` to seed UI filters without narrowing fetched data

## Why
- Counters and stats should reflect all fetched events on first load, not a subset filtered on the server.
- Infinite scroll and refresh logic append/replace with unfiltered data; removing initial server-side filtering makes behavior consistent across pages and refreshes.
- Aligns with the decision to not narrow content by type on the initial request while preserving optional UI filtering.

## Notes
- RSS endpoint behavior is unchanged; this change only affects the user page initial payload.
- Client-side filtering remains controlled by the `type` query param and can still hide/show categories without changing fetched data.

## Testing
- Start the app and open a user page, e.g., `/{username}`.
- Navigate to `/{username}?type=PushEvent,PullRequestEvent`:
  - Verify the timeline shows only those types, but the top summary counters reflect totals from all events in the first page.
  - Click Refresh and confirm counters remain consistent and timeline continues to honor the UI filter.
- Remove the `type` param and verify the timeline shows all event types.
- Scroll to load more pages and confirm items append correctly with consistent filtering and counters.
