### PR TITLE
Fix Workers pnpm build configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,9 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: >
-          pnpm install --frozen-lockfile
-          --config.only-built-dependencies=esbuild
-          --config.only-built-dependencies=sharp
-          --config.only-built-dependencies=workerd
+        run: |
+          pnpm install --frozen-lockfile --config.strict-dep-builds=false
+          pnpm rebuild esbuild sharp workerd
 
       - name: Run lint
         run: pnpm lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,11 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: >
+          pnpm install --frozen-lockfile
+          --config.only-built-dependencies=esbuild
+          --config.only-built-dependencies=sharp
+          --config.only-built-dependencies=workerd
 
       - name: Run lint
         run: pnpm lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
         with:
-          version: 10
+          version: 10.11.1
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,7 @@
-allowBuilds:
-  esbuild: true
-  sharp: true
-  workerd: true
+packages:
+  - .
+
+onlyBuiltDependencies:
+  - esbuild
+  - sharp
+  - workerd


### PR DESCRIPTION
## Summary
- Add the root package to pnpm-workspace.yaml so Workers Builds can read the workspace file safely
- Replace allowBuilds with onlyBuiltDependencies, which is compatible with the Workers Builds default pnpm 10.11.1
- Keep the same approved build-script dependencies: esbuild, sharp, and workerd

## Verification
- npx pnpm@10.11.1 install --frozen-lockfile
- npx pnpm@10.11.1 build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated workspace build configuration for dependency management.
* **Chores**
  * Bumped pnpm version used in CI to 10.11.1.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mkusaka/ghactivity/pull/140)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->