### PR TITLE
Add workflow lint

### DIFF
--- a/.github/scripts/check-codeql-sarif.mjs
+++ b/.github/scripts/check-codeql-sarif.mjs
@@ -1,0 +1,99 @@
+import { readFile } from "node:fs/promises";
+import { basename } from "node:path";
+
+const sarifPath = process.argv[2];
+
+if (!sarifPath) {
+  console.error("Usage: node check-codeql-sarif.mjs <sarif-file>");
+  process.exit(2);
+}
+
+const sarif = JSON.parse(await readFile(sarifPath, "utf8"));
+const findings = [];
+
+for (const run of sarif.runs ?? []) {
+  const driverRules = run.tool?.driver?.rules ?? [];
+  const rules = new Map(driverRules.map((rule) => [rule.id, rule]));
+
+  for (const result of run.results ?? []) {
+    if (isAcceptedSuppression(result)) {
+      continue;
+    }
+
+    const location = result.locations?.[0]?.physicalLocation;
+    const region = location?.region ?? {};
+    const uri = location?.artifactLocation?.uri ?? basename(sarifPath);
+    const rule = rules.get(result.ruleId) ?? {};
+    const message =
+      result.message?.text ??
+      result.message?.markdown ??
+      rule.shortDescription?.text ??
+      "CodeQL finding";
+
+    findings.push({
+      column: region.startColumn,
+      helpUri: rule.helpUri,
+      level: result.level ?? "warning",
+      line: region.startLine,
+      message,
+      ruleId: result.ruleId ?? "CodeQL",
+      uri,
+    });
+  }
+}
+
+if (findings.length === 0) {
+  console.log("No CodeQL findings.");
+  process.exit(0);
+}
+
+console.error(`CodeQL found ${findings.length} finding(s):`);
+
+for (const finding of findings) {
+  const location = [
+    finding.uri,
+    finding.line ? `:${finding.line}` : "",
+    finding.column ? `:${finding.column}` : "",
+  ].join("");
+  const help = finding.helpUri ? ` (${finding.helpUri})` : "";
+  const summaryPrefix = `- [${finding.level}] ${finding.ruleId} ${location} - `;
+  const summary = `${summaryPrefix}${finding.message}${help}`;
+  console.error(summary);
+  const annotationProperties = {
+    col: finding.column,
+    file: finding.uri,
+    line: finding.line,
+    title: `CodeQL ${finding.ruleId}`,
+  };
+  const propertyText = annotationPropertiesText(annotationProperties);
+  const escapedMessage = escapeMessage(finding.message);
+  console.error(`::error ${propertyText}::${escapedMessage}`);
+}
+
+process.exit(1);
+
+function isAcceptedSuppression(result) {
+  const suppressions = result.suppressions ?? [];
+  return suppressions.some((suppression) => suppression.status === "accepted");
+}
+
+function annotationPropertiesText(properties) {
+  const propertyText = Object.entries(properties)
+    .filter(([, value]) => value !== undefined)
+    .map(([key, value]) => `${key}=${escapeProperty(value)}`)
+    .join(",");
+
+  return propertyText;
+}
+
+function escapeMessage(value) {
+  let text = String(value);
+  text = text.replaceAll("%", "%25");
+  text = text.replaceAll("\r", "%0D");
+  text = text.replaceAll("\n", "%0A");
+  return text;
+}
+
+function escapeProperty(value) {
+  return escapeMessage(value).replaceAll(":", "%3A").replaceAll(",", "%2C");
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,4 @@
 name: CI
-
 on:
   push:
     branches:
@@ -7,15 +6,14 @@ on:
   pull_request:
     branches:
       - main
-
 jobs:
   ci:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
+        with:
+          persist-credentials: false
       - name: Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
@@ -26,20 +24,18 @@ jobs:
         with:
           node-version: 24
           cache: 'pnpm'
-
       - name: Install dependencies
         run: |
           pnpm install --frozen-lockfile --config.strict-dep-builds=false
           pnpm rebuild esbuild sharp workerd
-
       - name: Run lint
         run: pnpm lint
-
       - name: Run test
         run: pnpm test
-
       - name: Run typecheck
         run: pnpm typecheck:ci
-
       - name: Run build
         run: pnpm build
+    permissions: {}
+    timeout-minutes: 60
+permissions: {}

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -1,0 +1,152 @@
+name: workflow-lint
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+      - ".github/scripts/**"
+      - ".github/ghalint.yaml"
+      - ".pinact.yaml"
+      - "zizmor.yml"
+    types:
+      - opened
+      - reopened
+      - synchronize
+  workflow_dispatch: {}
+permissions: {}
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Download actionlint
+        id: get_actionlint
+        env:
+          # renovate: datasource=github-releases depName=rhysd/actionlint
+          ACTIONLINT_VERSION: v1.7.12
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          curl -sSfL -H "Authorization: token $GITHUB_TOKEN" -o /tmp/download-actionlint.bash "https://raw.githubusercontent.com/rhysd/actionlint/$ACTIONLINT_VERSION/scripts/download-actionlint.bash"
+          bash /tmp/download-actionlint.bash "${ACTIONLINT_VERSION#v}"
+        shell: bash
+      - name: Check workflow files
+        env:
+          ACTIONLINT_EXECUTABLE: ${{ steps.get_actionlint.outputs.executable }}
+        run: |
+          "$ACTIONLINT_EXECUTABLE" -color
+        shell: bash
+  ghalint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Download ghalint
+        env:
+          # renovate: datasource=github-releases depName=suzuki-shunsuke/ghalint
+          GHALINT_VERSION: v1.5.6
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          archive="ghalint_${GHALINT_VERSION#v}_linux_amd64.tar.gz"
+          curl -sSfL -H "Authorization: token $GITHUB_TOKEN" -o "/tmp/$archive" "https://github.com/suzuki-shunsuke/ghalint/releases/download/$GHALINT_VERSION/$archive"
+          curl -sSfL -H "Authorization: token $GITHUB_TOKEN" -o /tmp/ghalint_checksums.txt "https://github.com/suzuki-shunsuke/ghalint/releases/download/$GHALINT_VERSION/ghalint_${GHALINT_VERSION#v}_checksums.txt"
+          (cd /tmp && grep "  $archive\$" ghalint_checksums.txt | sha256sum -c -)
+          tar -xzf "/tmp/$archive" -C /tmp
+          sudo install -m 0755 /tmp/ghalint /usr/local/bin/ghalint
+          ghalint version
+        shell: bash
+      - name: Check workflow files
+        run: ghalint run
+        shell: bash
+      - name: Check action files
+        run: ghalint run-action
+        shell: bash
+  zizmor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions: {}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Run zizmor security check
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          inputs: .github/workflows/
+          min-severity: medium
+          token: ${{ github.token }}
+          advanced-security: false
+          annotations: true
+          version: v1.25.2 # renovate: depName=zizmorcore/zizmor
+  codeql-actions:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions: {}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
+        with:
+          languages: actions
+          queries: security-extended,security-and-quality
+      - name: Perform CodeQL analysis
+        id: analyze
+        uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
+        with:
+          category: /language:actions
+          output: ../results
+          upload: never
+          upload-database: false
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          package-manager-cache: false
+      - name: Check CodeQL findings
+        env:
+          SARIF_DIR: ${{ steps.analyze.outputs.sarif-output }}
+        run: |
+          set -euo pipefail
+
+          sarif_file="$(find "$SARIF_DIR" -name "*.sarif" -print -quit)"
+          if [[ -z "$sarif_file" ]]; then
+            echo "No CodeQL SARIF file was generated." >&2
+            exit 1
+          fi
+
+          node .github/scripts/check-codeql-sarif.mjs "$sarif_file"
+        shell: bash
+  pinact:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Download pinact
+        env:
+          # renovate: datasource=github-releases depName=suzuki-shunsuke/pinact
+          PINACT_VERSION: v3.10.1
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          archive="pinact_linux_amd64.tar.gz"
+          curl -sSfL -H "Authorization: token $GITHUB_TOKEN" -o "/tmp/$archive" "https://github.com/suzuki-shunsuke/pinact/releases/download/$PINACT_VERSION/$archive"
+          curl -sSfL -H "Authorization: token $GITHUB_TOKEN" -o /tmp/pinact_checksums.txt "https://github.com/suzuki-shunsuke/pinact/releases/download/$PINACT_VERSION/pinact_${PINACT_VERSION#v}_checksums.txt"
+          (cd /tmp && grep "  $archive\$" pinact_checksums.txt | sha256sum -c -)
+          tar -xzf "/tmp/$archive" -C /tmp
+          sudo install -m 0755 /tmp/pinact /usr/local/bin/pinact
+          pinact version
+        shell: bash
+      - name: Check pinned action refs
+        run: pinact run --check
+        shell: bash


### PR DESCRIPTION
## Summary
- Add or rename the workflow lint workflow.
- Run actionlint, ghalint, zizmor, CodeQL Actions analysis, and pinact for GitHub Actions files.
- Adjust existing workflow permissions, timeouts, pinned action refs, and auth/cache settings so the new checks pass.

## Testing
- `actionlint -color`
- `ghalint run`
- `ghalint run-action`
- `zizmor --min-severity medium .github/workflows/`
- `pinact run --check`
- `node --check .github/scripts/check-codeql-sarif.mjs`
